### PR TITLE
refactor: replace Editor.h with explicit includes

### DIFF
--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/UnrealMCPEditorCommands.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/UnrealMCPEditorCommands.cpp
@@ -1,6 +1,7 @@
 #include "Commands/UnrealMCPEditorCommands.h"
 #include "Commands/UnrealMCPCommonUtils.h"
-#include "Editor.h"
+#include "UnrealEdGlobals.h"
+#include "Editor/EditorEngine.h"
 #include "EditorViewportClient.h"
 #include "LevelEditorViewport.h"
 #include "ImageUtils.h"

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/UnrealMCPUMGCommands.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/UnrealMCPUMGCommands.cpp
@@ -1,6 +1,5 @@
 #include "Commands/UnrealMCPUMGCommands.h"
 #include "Commands/UnrealMCPCommonUtils.h"
-#include "Editor.h"
 #include "EditorAssetLibrary.h"
 #include "AssetRegistry/AssetRegistryModule.h"
 #include "Blueprint/UserWidget.h"

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/UnrealMCPModule.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/UnrealMCPModule.cpp
@@ -2,7 +2,6 @@
 #include "UnrealMCPBridge.h"
 #include "Modules/ModuleManager.h"
 #include "EditorSubsystem.h"
-#include "Editor.h"
 
 #define LOCTEXT_NAMESPACE "FUnrealMCPModule"
 


### PR DESCRIPTION
## Summary
- remove `Editor.h` from UnrealMCP plugin sources
- include `UnrealEdGlobals.h` and `Editor/EditorEngine.h` where `GEditor` is used

## Testing
- `pre-commit run --files MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/UnrealMCPUMGCommands.cpp MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/UnrealMCPEditorCommands.cpp MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/UnrealMCPModule.cpp` *(command not found: pre-commit)*
- `bash MCPGameProject/Build.sh` *(No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a6083a7b1083279ad50d1985c75f93