### PR TITLE
Include Package header in UMG commands

### DIFF
--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/UnrealMCPUMGCommands.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/UnrealMCPUMGCommands.cpp
@@ -24,6 +24,7 @@
 #include "Kismet/GameplayStatics.h"
 #include "Kismet2/KismetEditorUtilities.h"
 #include "K2Node_Event.h"
+#include "UObject/Package.h"
 
 FUnrealMCPUMGCommands::FUnrealMCPUMGCommands()
 {


### PR DESCRIPTION
## Summary
- include UObject/Package.h in UnrealMCPUMGCommands.cpp for explicit UPackage usage

## Testing
- `UnrealBuildTool MCPGameProjectEditor Linux Development -Project="MCPGameProject/MCPGameProject.uproject"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a609bb855883279d6d6ed992159e95