### PR TITLE
Specify UE 5.6 engine version in plugin

### DIFF
--- a/MCPGameProject/Plugins/UnrealMCP/UnrealMCP.uplugin
+++ b/MCPGameProject/Plugins/UnrealMCP/UnrealMCP.uplugin
@@ -7,13 +7,14 @@
 	"Category": "Editor",
 	"CreatedBy": "Your Name",
 	"CreatedByURL": "",
-	"DocsURL": "",
-	"MarketplaceURL": "",
-	"SupportURL": "",
-	"CanContainContent": true,
-	"IsBetaVersion": false,
-	"IsExperimentalVersion": false,
-	"Installed": false,
+        "DocsURL": "",
+        "MarketplaceURL": "",
+        "SupportURL": "",
+        "EngineVersion": "5.6.0",
+        "CanContainContent": true,
+        "IsBetaVersion": false,
+        "IsExperimentalVersion": false,
+        "Installed": false,
 	"Modules": [
 		{
 			"Name": "UnrealMCP",
@@ -26,10 +27,10 @@
 			]
 		}
 	],
-	"Plugins": [
-		{
-			"Name": "EditorScriptingUtilities",
-			"Enabled": true
-		}
-	]
-} 
+        "Plugins": [
+                {
+                        "Name": "EditorScriptingUtilities",
+                        "Enabled": true
+                }
+        ]
+}


### PR DESCRIPTION
## Summary
- declare engine version 5.6.0 for UnrealMCP plugin

## Testing
- `python -m pytest`
- ⚠️ `UnrealEditor MCPGameProject/MCPGameProject.uproject -NoSplash -NullRHI` (command not found)


------
https://chatgpt.com/codex/tasks/task_e_68a60acab3388327b029ea780f3c5c0e