### PR TITLE
Document BuildCookRun attempt

### DIFF
--- a/Docs/BuildCookRun.md
+++ b/Docs/BuildCookRun.md
@@ -1,0 +1,15 @@
+# BuildCookRun Attempt
+
+An attempt was made to build and cook the sample project using Unreal's Automation Tool:
+
+```bash
+./Engine/Build/BatchFiles/RunUAT.sh BuildCookRun -project=MCPGameProject/MCPGameProject.uproject -nop4 -cook -stage -archive
+```
+
+The command failed because the Unreal Engine `RunUAT.sh` script could not be found:
+
+```
+bash: ./Engine/Build/BatchFiles/RunUAT.sh: No such file or directory
+```
+
+Ensure that Unreal Engine 5.6 or later is installed and that the command is executed from the root of the engine installation. Once the engine is available, rerun the above command to build and cook the project.

--- a/Docs/README.md
+++ b/Docs/README.md
@@ -3,6 +3,6 @@
 Welcome to the documentation for the Unreal Engine Model Context Protocol (MCP) integration. This documentation will help you understand, set up, and use the MCP system with Unreal Engine.
 
 ## Contents
-
+- [BuildCookRun results](BuildCookRun.md) - Notes on running the automated build.
 - [Tools](Tools/README.md) - All the tools that are available.
 


### PR DESCRIPTION
## Summary
- Documented BuildCookRun command usage and missing `RunUAT.sh` script
- Linked build notes from documentation index

## Testing
- `./Engine/Build/BatchFiles/RunUAT.sh BuildCookRun -project=MCPGameProject/MCPGameProject.uproject -nop4 -cook -stage -archive` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a60ce75ac083278e434bb12c72e408